### PR TITLE
Deliver default secrets if no SD card available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .vscode/launch.json
 .vscode/ipch
 output.map
+src/secrets.local/*

--- a/lib/secrets/secrets.c
+++ b/lib/secrets/secrets.c
@@ -1,0 +1,28 @@
+#include "secrets.h"
+
+/**
+ * @file
+ * @brief   Secrets-Template
+ * 
+ *          Create a c-file in the folder `src/secrets.local` where you declare 
+ *          your local secrets. The folder is exempt from version control, so 
+ *          your secrets are not accidentially published.
+ *
+ * @author  Ueli Niederer
+ * @date    04.10.2023
+ *
+ * @copyright Copyright (c) 2023 GBS St.Gallen
+ */
+
+__attribute__((weak)) tSecretsWifi secrets_wifi = {
+    .ssid = "default",
+    .passkey = "default"
+};
+
+__attribute__((weak)) tSecretsMqtt secrets_mqtt = {
+    .broker = "192.168.178.48",
+    .clientId = "",
+    .port = 1883,
+    .user = "",
+    .password = "",
+};

--- a/lib/secrets/secrets.h
+++ b/lib/secrets/secrets.h
@@ -1,26 +1,32 @@
+#pragma once
+
 /**
- * @file secrets.h
- * @author Beat Sturzenegger / Fabian Reifler
- * @brief Zugangsdaten für die WiFi Verbindung und den MQTT Broker
- * @version 1.1
- * @date 08.03.2023
+ * @file
+ * @brief   (Default) secrets for accessing WiFi and MQTT Broker
  *
- * @copyright Copyright (c) 2023
+ * @author  Ueli Niederer
+ * @date    04.10.2023
  *
+ * @copyright Copyright (c) 2023 GBS St.Gallen
  */
 
-#ifndef SECRETS_H
-#define SECRETS_H
+#include <stdint.h>
 
 // WiFi data
-//const char *ssid = "";     ///< WLAN SSID
-//const char *password = ""; ///< WLAN Password
+typedef struct sSecretsWifi {
+    const char *ssid;
+    const char *passkey;
+}tSecretsWifi;
+
+extern tSecretsWifi secrets_wifi;
 
 // MQTT data
-//const char *default_mqtt_broker = "192.168.178.48"; ///< MQTT Broker URL
-//const uint16_t mqtt_bootstrap_broker_port = 1883;         ///< port for the Broker
-//const char *mqtt_bootstrap_broker_user = "";                     ///< user for the Broker
-//const char *mqtt_bootstrap_broker_password = "";        ///< password for the Broker
-//const char *mqtt_bootstrap_broker_id = "";                       ///< not used yet
+typedef struct sSecretsMqtt {
+    const char *broker;
+    uint16_t    port;
+    const char *clientId;
+    const char *user;
+    const char *password;
+}tSecretsMqtt;
 
-#endif
+extern tSecretsMqtt secrets_mqtt;

--- a/src/readConfigSDCard.cpp
+++ b/src/readConfigSDCard.cpp
@@ -1,7 +1,11 @@
 #include <SPI.h>
 #include <Seeed_FS.h> // SD card library
+#include <secrets.h>
+
 #include "ArduinoJson.h"
 #include "SD/Seeed_SD.h"
+
+static const char *ValueGetOrDefault(const char *key, const char *default_value);
 
 static StaticJsonDocument<500> jsonDocConfigFile;
 
@@ -38,36 +42,37 @@ void readConfigFromSDCard()
 
 const char *getWifiSSID()
 {
-  return jsonDocConfigFile["SSID"];
+  return ValueGetOrDefault("SSID", secrets_wifi.ssid);
 }
 
 const char *getWifiPW()
 {
-  return jsonDocConfigFile["PW"];
+  return ValueGetOrDefault("PW", secrets_wifi.passkey);
 }
 
 const char *getWioTerminalID()
 {
-  return jsonDocConfigFile["ID"];
+  return ValueGetOrDefault("ID", "0");
 }
 
 const char *getWioTerminalFuntionality()
 {
-  return jsonDocConfigFile["default_functionality"];
+  return ValueGetOrDefault("default_functionality", "");
 }
 
 const char *getMQTTBroker(){
-  return jsonDocConfigFile["mqtt_bootstrap_broker"];
+  return ValueGetOrDefault("mqtt_bootstrap_broker", secrets_mqtt.broker);
 }
 
 const char *getMQTTUser(){
-  return jsonDocConfigFile["mqtt_bootstrap_broker_user"];
+  return ValueGetOrDefault("mqtt_bootstrap_broker_user", secrets_mqtt.user);
 } 
 
 const char *getMQTTPW(){
-  return jsonDocConfigFile["mqtt_bootstrap_broker_password"];
+  return ValueGetOrDefault("mqtt_bootstrap_broker_password", secrets_mqtt.password);
 }
 
-
-
-
+static const char *ValueGetOrDefault(const char *key, const char *default_value) {
+  const char *result = jsonDocConfigFile[key];
+  return result ? result : default_value;
+}


### PR DESCRIPTION
I found this piece of code lying around allowing to setup default credentials/setup in case the SD card not delivering the expected JSON attributes.

For protection, proper secrets can be stored by copying the `secrets.c`- file into `src/secrets.local/` which is ignored by git (so you don't accidentially share the secrets with the world ;-) ) and enter the proper credentials in that file.